### PR TITLE
[FEATURE][000] - Enable Studio Bot project context sharing

### DIFF
--- a/.idea/studiobot.xml
+++ b/.idea/studiobot.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="StudioBotProjectSettings">
+    <option name="shareContext" value="OptedIn" />
+  </component>
+</project>


### PR DESCRIPTION
This change updates the Studio Bot project settings to opt-in to sharing context with the Studio Bot service. This allows Studio Bot to provide more relevant and helpful suggestions by understanding the project's structure and dependencies.